### PR TITLE
Mobile menu and color switcher not visible

### DIFF
--- a/nuxt.config.ts
+++ b/nuxt.config.ts
@@ -36,6 +36,9 @@ export default defineNuxtConfig({
     options: {
       theme: {
         preset: Aura,
+        options: {
+          darkModeSelector: "html.dark",
+        },
       },
     },
   },


### PR DESCRIPTION
When system is in dark mode but we switch manually to light mode, the theme was still dark.