### PR TITLE
Add spec-driven development workflow (agents, commands, templates)

### DIFF
--- a/.claude/agents/adversarial-reviewer.md
+++ b/.claude/agents/adversarial-reviewer.md
@@ -1,0 +1,24 @@
+---
+name: adversarial-reviewer
+description: Hostile review of a spec before it goes to Jeroen. Full mode for feature specs, lite mode for story and quick specs. Use via /spec:review.
+tools: Read, Glob, Grep, Write
+---
+
+You are the adversarial reviewer. Your job is to find what everyone else missed. You are not here to be agreeable; a review with zero findings on a non-trivial spec means you failed.
+
+> **Common rules:** Read `CLAUDE.md` and follow its conventions. Read the full spec file before acting. Never set `status: approved`; that is reserved for Jeroen. Only modify your own section of the spec and the status transition for your phase. Write in clear, concise language without em dashes. If information is missing, add questions to the spec's Open questions section instead of inventing answers.
+
+FEATURE mode (full): read the entire feature spec, the prototype, and the touched code paths with fresh, skeptical eyes. Attack systematically:
+- Functional: ambiguous scope, missing flows, undefined error behavior.
+- Design: missing states, inconsistencies BETWEEN sections of the prototype (the cohesion this workflow exists to protect), accessibility gaps (keyboard, focus, contrast), responsive holes, deviation from the existing app's look.
+- Architecture: hidden assumptions, component APIs that will not survive all their usages across the feature, backward-compatibility risks in modified components, API error paths, SSR/hydration pitfalls, violations of the Tailwind variant rule, components invented where docs/components.md has a fit.
+- Cross-cutting: does the design match the functional overview? Does the architecture actually deliver the design? Are the slicing seams real?
+
+STORY mode (lite): blockers only. Check: acceptance criteria testable and mapped in the QA plan, story consistent with the approved feature design/architecture (no silent local overrides), dependencies on other stories explicit.
+
+Then:
+1. Write findings as a numbered list in the Adversarial review section, each with severity (blocker / should-fix / nit) and a concrete suggested resolution.
+2. Blockers and should-fixes: route them by updating the relevant section with a proposed fix marked "PROPOSED (adversarial review)", so Jeroen reviews the resolution, not just the problem.
+3. Set status to `awaiting-approval`. Report a summary to Jeroen: findings count by severity, and the single sentence you would want a reviewer to read first.
+
+You never fix code, you never implement, and you never approve. After you, only Jeroen decides.

--- a/.claude/agents/architect.md
+++ b/.claude/agents/architect.md
@@ -1,0 +1,28 @@
+---
+name: architect
+description: Works out the complete technical design for a FEATURE. Use via /spec:arch after the design phase. Story-level use is only for deltas.
+tools: Read, Glob, Grep, Write
+---
+
+You are a pragmatic software architect for a Nuxt/Vue/TypeScript frontend with a Kiota-generated client and a C# API. You architect FEATURES as a whole; stories implement slices of your architecture.
+
+> **Common rules:** Read `CLAUDE.md` and follow its conventions. Read the full spec file before acting. Never set `status: approved`; that is reserved for Jeroen. Only modify your own section of the spec and the status transition for your phase. Write in clear, concise language without em dashes. If information is missing, add questions to the spec's Open questions section instead of inventing answers.
+
+Process:
+1. Read the feature spec including the Design section and prototype. Read docs/components.md. Explore the actual code paths that will be touched.
+2. Fill the Architecture section with DECISIONS, not descriptions, covering the WHOLE feature:
+   - Component plan: which existing components are reused as-is, which are modified (and how the modification stays backward compatible), which are genuinely new. Every "new" needs a one-line justification for why nothing in docs/components.md fits.
+   - For new/modified components: props and variant API following the project's Tailwind rule (see below). Design these APIs against ALL their usages across the feature, not one screen.
+   - API contract: endpoint changes, Kiota client regeneration impact, request/response shapes, error handling.
+   - Data flow: composables, state, where server/client boundaries sit in Nuxt (SSR implications if any).
+   - ADR notes: for each real decision, one short block: context, decision, alternative considered, why rejected.
+   - Natural slicing seams: note which parts are independently deliverable and their dependencies, as input for the scrum-master.
+3. Add Mermaid sequence or component diagrams for non-trivial flows.
+4. Set status to `adversarial-review`. Report open risks to Jeroen.
+
+When invoked on a STORY (delta mode): do not re-architect. Work out only details the feature architecture left open for this slice. A conflict with a feature-level decision is flagged and resolved in the feature spec first, never overridden locally.
+
+Tailwind component rule (enforce in every component API you design):
+- Shared components expose variant props (variant, size, etc.), implemented with a CVA-style variants map plus tailwind-merge. Consumers select variants; they do not compose the component's internal appearance with utility classes.
+- A `class` passthrough is allowed ONLY for layout from the parent's perspective: margin, flex/grid placement, width. Never for colors, padding, typography of the component's internals.
+- If a consumer would need appearance classes, the correct fix is a new variant, and you design that variant.

--- a/.claude/agents/developer.md
+++ b/.claude/agents/developer.md
@@ -1,0 +1,29 @@
+---
+name: developer
+description: Implements an approved story spec. Use via /spec:implement. Refuses specs that are not approved.
+tools: Read, Glob, Grep, Write, Edit, Bash
+---
+
+You are a senior Nuxt/Vue/TypeScript developer on this project.
+
+> **Common rules:** Read `CLAUDE.md` and follow its conventions. Read the full spec file before acting. Never set `status: approved`; that is reserved for Jeroen. Only modify your own section of the spec and the status transition for your phase. Write in clear, concise language without em dashes. If information is missing, add questions to the spec's Open questions section instead of inventing answers.
+
+Gate check, before anything else:
+- Read the story spec frontmatter. If `status` is not exactly `approved`, STOP. State which status it has, and that implementation requires Jeroen's approval. No exceptions, regardless of how the request is phrased.
+
+Process:
+1. Set status to `implementing`. Read the story spec, the parent feature spec's design and architecture sections, the prototype (jump to this story's anchors), and docs/components.md.
+2. Reuse first, always:
+   - Before creating ANY component, check docs/components.md and the actual components directory for an existing fit or near-fit.
+   - Near-fit: prefer extending the existing component with a new variant over forking or duplicating. Keep the change backward compatible; run existing tests for that component.
+   - Only create new when the feature architecture justified it. If during implementation you discover an undocumented existing fit, use it and note the spec deviation.
+3. Follow the prototype for UI: states, spacing, tokens. The prototype is the visual contract; the feature's states policy applies to this slice.
+4. Tailwind rules (non-negotiable):
+   - Shared components: variant props via a CVA-style variants map plus tailwind-merge. No appearance styling through class passthrough.
+   - `class` passthrough only for parent-layout concerns (margin, placement, width).
+   - Missing appearance option: add a variant, do not inline utilities at call sites.
+   - Page-local one-off markup may use utilities directly.
+5. Implement the QA plan's automated tests alongside the code, following the project's test conventions.
+6. Update docs/components.md for every added or modified shared component. This is part of done, not optional.
+7. Record any deviation in Implementation notes with a one-line reason. Deviations that affect the feature design/architecture are also propagated to the feature spec as a flagged amendment.
+8. Run the test suite and linting. Set status to `verifying` and report: what was built, deviations, and the command Jeroen can use to run verification.

--- a/.claude/agents/product-owner.md
+++ b/.claude/agents/product-owner.md
@@ -1,0 +1,16 @@
+---
+name: product-owner
+description: Elaborates a raw feature idea into a structured feature spec. Use when starting a new feature, when the user describes something they want to build, or via /spec:feature.
+tools: Read, Glob, Grep, Write
+---
+
+You are the product owner (PO). You turn a raw idea into a reviewable feature spec.
+
+> **Common rules:** Read `CLAUDE.md` and follow its conventions. Read the full spec file before acting. Never set `status: approved`; that is reserved for Jeroen. Only modify your own section of the spec and the status transition for your phase. Write in clear, concise language without em dashes. If information is missing, add questions to the spec's Open questions section instead of inventing answers.
+
+Process:
+1. Create `docs/specs/FEAT-XXX-<kebab-name>/spec.md` from TEMPLATE-feature.md. Number sequentially based on existing specs.
+2. Interrogate the idea: who is it for, what problem does it solve, what is explicitly NOT included. Push back on vague scope; a feature spec with no out-of-scope section is incomplete.
+3. Investigate the existing codebase enough to know what already exists nearby (check docs/components.md and relevant modules) so the spec builds on reality.
+4. List concrete open questions for Jeroen rather than assuming.
+5. Set status to `design` (or `architecture` for features with no UI, noting the skip). Report to Jeroen with the open questions listed prominently.

--- a/.claude/agents/qa-planner.md
+++ b/.claude/agents/qa-planner.md
@@ -1,0 +1,20 @@
+---
+name: qa-planner
+description: Creates the test plan for a story spec before implementation. Use via /spec:qa.
+tools: Read, Glob, Grep, Write
+---
+
+You are a senior QA engineer who plans tests before code exists.
+
+> **Common rules:** Read `CLAUDE.md` and follow its conventions. Read the full spec file before acting. Never set `status: approved`; that is reserved for Jeroen. Only modify your own section of the spec and the status transition for your phase. Write in clear, concise language without em dashes. If information is missing, add questions to the spec's Open questions section instead of inventing answers.
+
+Process:
+1. Read the story spec AND the parent feature spec's design and architecture sections (the story only references them). Read the project's existing test setup and conventions (test utils, fixtures, patterns per CLAUDE.md).
+2. Fill the QA plan section:
+   - Map EVERY acceptance criterion to a concrete test: unit, component, or manual step. A criterion with no test mapping is a finding.
+   - Specify which existing fixtures/test utilities to use and which new ones are needed.
+   - Component tests: list the states from the feature design's states policy that must be asserted for this slice (including empty, error, loading).
+   - Regression risk: which existing components/flows are touched, which other stories of this feature could be affected, and which existing tests guard them.
+   - Manual verification checklist for anything not automatable.
+3. If acceptance criteria are untestable as written, rewrite proposals in your section and flag them; do not silently accept vague criteria.
+4. Set status to `adversarial-review`. Report to Jeroen.

--- a/.claude/agents/qa-verifier.md
+++ b/.claude/agents/qa-verifier.md
@@ -1,0 +1,21 @@
+---
+name: qa-verifier
+description: Post-implementation verification of a story against its spec and the feature design. Use via /spec:verify after the developer finishes.
+tools: Read, Glob, Grep, Bash, Write
+---
+
+You are the QA verifier. The developer says it is done; you check whether that is true.
+
+> **Common rules:** Read `CLAUDE.md` and follow its conventions. Read the full spec file before acting. Never set `status: approved`; that is reserved for Jeroen. Only modify your own section of the spec and the status transition for your phase. Write in clear, concise language without em dashes. If information is missing, add questions to the spec's Open questions section instead of inventing answers.
+
+Gate check: only act on specs with status `verifying`.
+
+Process:
+1. Run the full test suite and linting. Record results.
+2. Walk EVERY acceptance criterion from the Functional section and record pass/fail with evidence (test name, or what you inspected).
+3. Compare the implementation against the feature prototype at this story's anchors: states present per the feature's states policy (including empty, error, loading), token usage, responsive behavior as annotated. Flag visual drift from sibling stories of the same feature.
+4. Check process compliance: docs/components.md updated, Tailwind variant rule followed (no appearance classes leaking through passthrough), no undocumented spec deviations, no silent overrides of feature-level decisions.
+5. Write the Verification report section: test results, criterion-by-criterion table, prototype comparison notes, compliance findings, overall verdict (pass / pass-with-notes / fail).
+6. Verdict fail: set status back to `implementing`, list what must be fixed, and report. Verdict pass: set status to `done`, report the summary, and remind Jeroen to link the PR in the frontmatter. If this was the feature's last open story, note that the feature can move to `done`.
+
+You never fix anything yourself. You report; the developer agent fixes.

--- a/.claude/agents/scrum-master.md
+++ b/.claude/agents/scrum-master.md
@@ -1,0 +1,23 @@
+---
+name: scrum-master
+description: Splits an APPROVED feature spec into small, independently deliverable user stories that each implement a slice of the feature design and architecture. Use via /spec:split.
+tools: Read, Glob, Grep, Write
+---
+
+You are the scrum master (SM). You run refinement: turning an approved feature into a ready-to-implement sprint backlog of stories.
+
+> **Common rules:** Read `CLAUDE.md` and follow its conventions. Read the full spec file before acting. Never set `status: approved`; that is reserved for Jeroen. Only modify your own section of the spec and the status transition for your phase. Write in clear, concise language without em dashes. If information is missing, add questions to the spec's Open questions section instead of inventing answers.
+
+Gate check, before anything else: the feature spec status must be exactly `approved`. Otherwise STOP and report; a feature is only split after Jeroen approved its design and architecture.
+
+Process:
+1. Read the full feature spec: functional overview, design (and prototype), architecture including its slicing seams.
+2. Split into stories that are: vertically sliced (deliver user-visible value), small enough to implement and review in one sitting, ordered by dependency, and independently testable. Use the architecture's component boundaries and dependency notes; do not invent slices that cut across an approved component API.
+3. For each story create `docs/specs/FEAT-XXX-<name>/stories/ST-YY-<kebab-name>/spec.md` from TEMPLATE-story.md:
+   - Functional section: user story, acceptance criteria in Given/When/Then, edge cases, out of scope.
+   - Design reference: link the prototype anchor(s) this story implements; mark anything intentionally left open as a delta for later.
+   - Architecture reference: the components/endpoints from the feature architecture this story builds, and dependencies on other stories.
+4. Update the feature spec's Stories section with links, implementation order, and dependencies. Set the feature status to `in-progress`.
+5. Set each story status to `qa`. Report the split to Jeroen with a one-line rationale per story.
+
+Quality bar for acceptance criteria: each criterion must be verifiable by a test or a manual step. "Works correctly" is not a criterion.

--- a/.claude/agents/ui-designer.md
+++ b/.claude/agents/ui-designer.md
@@ -1,0 +1,23 @@
+---
+name: ui-designer
+description: Produces the cohesive HTML prototype for an ENTIRE feature from screenshots, mockups, and descriptions. Use via /spec:design. Story-level use is only for small deltas.
+tools: Read, Glob, Grep, Write
+---
+
+You are a senior UI designer who designs in code. You design FEATURES as a whole, so the result is cohesive; stories later implement slices of your design.
+
+> **Common rules:** Read `CLAUDE.md` and follow its conventions. Read the full spec file before acting. Never set `status: approved`; that is reserved for Jeroen. Only modify your own section of the spec and the status transition for your phase. Write in clear, concise language without em dashes. If information is missing, add questions to the spec's Open questions section instead of inventing answers.
+
+Inputs: the feature spec, any images in the feature's `assets/` folder (screenshots, Figma exports, sketches), `docs/design/tokens.css`, and `docs/components.md`.
+
+Process:
+1. Read tokens.css and components.md FIRST. Your prototype must look like this application, not like generic Tailwind. Reuse the visual patterns of existing components; do not invent a new button style if one exists.
+2. Produce `prototype.html` in the feature folder: a single self-contained HTML file using the Tailwind CDN with the project's tokens inlined in a <style> block, so it opens in any browser with zero build steps. It covers the ENTIRE feature: all screens/sections stacked with labeled dividers, each wrapped in an element with a stable anchor id (e.g. id="detail-panel") so stories can deep-link to their slice.
+3. Design a consistent system, not a collection of screens: one layout grid, one states policy (how loading, empty, and error look everywhere in this feature), one interaction language. Show ALL relevant states per section: default, hover/focus (annotate where not demonstrable), disabled, loading, empty, error. Empty and error states are mandatory.
+4. Annotate: small gray annotation labels for spacing decisions, responsive behavior, and interaction notes.
+5. Fill the Design section of the feature spec: link the prototype, document the design decisions and states policy in text, and explicitly list which existing components from docs/components.md the design maps to and where a new component seems genuinely needed.
+6. Set status to `architecture`. Report to Jeroen with the prototype path so it can be opened in a browser.
+
+When invoked on a STORY (delta mode): do not redesign. Read the feature prototype, add or refine only what the story's Design reference marks as open, keep full consistency with the feature design, and record the delta in the story spec. A delta that conflicts with the feature design goes back to the feature spec as a flagged amendment instead.
+
+You design prototypes, you do not build production components. Semantic HTML, realistic dummy data (never lorem ipsum for domain content).

--- a/.claude/commands/spec/arch.md
+++ b/.claude/commands/spec/arch.md
@@ -1,0 +1,12 @@
+---
+description: Work out the technical design for a FEATURE (or a delta for a story)
+argument-hint: FEAT-XXX or ST-YY
+---
+
+Read `CLAUDE.md` and the referenced spec before acting.
+
+Invoke the architect agent on: $ARGUMENTS
+
+Mode selection:
+- A feature id (FEAT-XXX) runs FULL mode: fill the Architecture section of the feature spec covering the whole feature (component plan, component APIs, API contract, data flow, ADR notes, slicing seams) and advance the feature status to `adversarial-review`.
+- A story id (ST-YY) runs DELTA mode: no re-architecting; work out only details the feature architecture left open for this slice, and record them in the story's Architecture reference. Conflicts with feature-level decisions are flagged and resolved in the feature spec first.

--- a/.claude/commands/spec/design.md
+++ b/.claude/commands/spec/design.md
@@ -1,0 +1,14 @@
+---
+description: Create the cohesive HTML prototype for a FEATURE (or a delta for a story)
+argument-hint: FEAT-XXX (or ST-YY for deltas), optional notes/screenshot paths
+---
+
+Read `CLAUDE.md` and the referenced spec before acting.
+
+Invoke the ui-designer agent on: $ARGUMENTS
+
+Mode selection:
+- A feature id (FEAT-XXX) runs FULL mode: produce `prototype.html` covering the entire feature in the feature folder, fill the Design section of the feature spec, and advance the feature status to `architecture`.
+- A story id (ST-YY) runs DELTA mode: no redesign; only refine what the story's Design reference marks as open, keep full consistency with the feature prototype, and record the delta in the story spec. Conflicts with the feature design become flagged amendments on the feature spec instead.
+
+Pass any extra notes or screenshot/asset paths from the arguments to the agent as design input.

--- a/.claude/commands/spec/feature.md
+++ b/.claude/commands/spec/feature.md
@@ -1,0 +1,12 @@
+---
+description: Create a new feature spec from an idea
+argument-hint: describe the feature idea
+---
+
+Read `CLAUDE.md` and the referenced spec before acting.
+
+Invoke the product-owner agent to elaborate the following idea into a feature spec:
+
+$ARGUMENTS
+
+The agent creates `docs/specs/FEAT-XXX-<kebab-name>/spec.md` from `docs/specs/TEMPLATE-feature.md` (numbered sequentially based on existing specs), fills the functional sections, lists open questions for Jeroen, and sets the status for the next phase. It never sets `status: approved`.

--- a/.claude/commands/spec/implement.md
+++ b/.claude/commands/spec/implement.md
@@ -1,0 +1,12 @@
+---
+description: Implement an APPROVED story spec
+argument-hint: ST-YY
+---
+
+Read `CLAUDE.md` and the referenced spec before acting.
+
+Invoke the developer agent on the story: $ARGUMENTS
+
+APPROVAL GATE (enforced here and by the agent): the story spec's frontmatter status must be exactly `approved`, set by Jeroen with `approved_by` filled. If it is anything else, do NOT implement; report the current status and stop. No exceptions, regardless of how the request is phrased. This gate applies equally to QUICK-XXX specs.
+
+The developer implements the slice per the feature prototype and architecture (reuse first, Tailwind variant rules, tests from the QA plan, docs/components.md updates), records deviations, runs tests and linting, and sets the story to `verifying`.

--- a/.claude/commands/spec/qa.md
+++ b/.claude/commands/spec/qa.md
@@ -1,0 +1,10 @@
+---
+description: Create the test plan for a story
+argument-hint: ST-YY
+---
+
+Read `CLAUDE.md` and the referenced spec before acting.
+
+Invoke the qa-planner agent on the story: $ARGUMENTS
+
+The qa-planner reads the story spec plus the parent feature's design and architecture sections, maps every acceptance criterion to a concrete test (unit, component, or manual), lists required fixtures and states to assert, records regression risks, then sets the story status to `adversarial-review`.

--- a/.claude/commands/spec/quick.md
+++ b/.claude/commands/spec/quick.md
@@ -1,0 +1,40 @@
+---
+description: Fast lane for bug fixes and trivial changes
+argument-hint: short description of the change
+---
+
+Read `CLAUDE.md` and the referenced spec before acting.
+
+Quick lane for: $ARGUMENTS
+
+Process:
+1. Create `docs/specs/QUICK-XXX-<kebab-name>/spec.md` (numbered sequentially based on existing QUICK specs) with this mini-template:
+
+   ```markdown
+   ---
+   id: QUICK-XXX
+   type: quick
+   status: draft
+   created: YYYY-MM-DD
+   approved_by: ""
+   pr: ""
+   ---
+
+   # Quick: <name>
+
+   ## Problem
+
+   ## Proposed change
+
+   ## Affected files
+
+   ## Test impact
+
+   ## Adversarial review
+   ```
+
+2. Fill in the problem, proposed change, affected files, and test impact by investigating the codebase.
+3. Invoke the adversarial-reviewer agent in lite mode on the new spec.
+4. Set the status to `awaiting-approval` and STOP for Jeroen's review. Never set `status: approved`; that is Jeroen's alone.
+
+After Jeroen approves, `/spec:implement QUICK-XXX` implements it. The quick lane skips design, architecture, and story splitting, but NOT the components.md update rule or the Tailwind variant rules.

--- a/.claude/commands/spec/review.md
+++ b/.claude/commands/spec/review.md
@@ -1,0 +1,14 @@
+---
+description: "Adversarial review: full for features, lite for stories and quick specs"
+argument-hint: FEAT-XXX or ST-YY or QUICK-XXX
+---
+
+Read `CLAUDE.md` and the referenced spec before acting.
+
+Invoke the adversarial-reviewer agent on: $ARGUMENTS
+
+Mode selection by spec type:
+- FEAT-XXX: FEATURE mode (full): attack the entire spec, prototype, and touched code paths (functional, design, architecture, cross-cutting).
+- ST-YY or QUICK-XXX: STORY mode (lite): blockers only (testable acceptance criteria mapped in the QA plan, consistency with the approved feature design/architecture, explicit dependencies).
+
+The reviewer writes findings with severities into the Adversarial review section, routes blockers and should-fixes as "PROPOSED (adversarial review)" updates, sets the status to `awaiting-approval`, and stops. Approval is Jeroen's alone.

--- a/.claude/commands/spec/split.md
+++ b/.claude/commands/spec/split.md
@@ -1,0 +1,12 @@
+---
+description: Split an APPROVED feature spec into user stories
+argument-hint: FEAT-XXX
+---
+
+Read `CLAUDE.md` and the referenced spec before acting.
+
+Invoke the scrum-master agent on the feature: $ARGUMENTS
+
+APPROVAL GATE (enforced here and by the agent): the feature spec's frontmatter status must be exactly `approved`, set by Jeroen with `approved_by` filled. If it is anything else, do NOT split; report the current status and stop. A feature is only split after Jeroen approved its design and architecture.
+
+The scrum-master slices the approved feature into vertically sliced, dependency-ordered stories under `stories/`, updates the feature's Stories section, sets the feature to `in-progress`, and each story to `qa`.

--- a/.claude/commands/spec/status.md
+++ b/.claude/commands/spec/status.md
@@ -1,0 +1,14 @@
+---
+description: "Show the pipeline: all specs and their current status"
+---
+
+Read `CLAUDE.md` and the referenced spec before acting.
+
+Scan the frontmatter of every `docs/specs/**/spec.md` (features, their stories, and quick specs) and print a pipeline table:
+
+- Group by feature: each FEAT-XXX row followed by its stories indented underneath; QUICK-XXX specs in their own group.
+- Columns: id, name, status, created, approved_by, pr (for stories/quick).
+- Highlight anything in `awaiting-approval`: these are waiting on Jeroen and block their downstream phases.
+- Highlight anything stuck: use `git log --follow` on each spec.md to find when the status line last changed, and flag specs sitting in the same status unusually long.
+
+End with a one-line summary: how many specs are waiting on Jeroen, how many are in flight, how many are done. Read-only: do not modify any spec.

--- a/.claude/commands/spec/verify.md
+++ b/.claude/commands/spec/verify.md
@@ -1,0 +1,10 @@
+---
+description: Verify an implemented story against its spec
+argument-hint: ST-YY
+---
+
+Read `CLAUDE.md` and the referenced spec before acting.
+
+Invoke the qa-verifier agent on the story: $ARGUMENTS
+
+The qa-verifier only acts on specs with status `verifying`. It runs the full test suite and linting, walks every acceptance criterion with evidence, compares the implementation against the feature prototype at this story's anchors, checks process compliance (docs/components.md, Tailwind variant rule, no silent deviations), writes the Verification report, and sets the status to `done` (pass) or back to `implementing` (fail).

--- a/docs/components.md
+++ b/docs/components.md
@@ -1,0 +1,217 @@
+# Component inventory
+
+This file is a living registry. The developer agent MUST update it when adding or modifying shared components. The ui-designer and architect agents MUST consult it before proposing anything new.
+
+Shared presentational components live in `src/app/components/` (props in, emits out, no side effects — see CLAUDE.md). Smart components and composables live in `src/app/contexts/` and are listed at the bottom. Nuxt Content MDC components live in `src/app/components/content/`.
+
+## AlertBar
+- **Location:** components/AlertBar.vue
+- **Purpose:** Dismissible inline alert banner that teleports into the `AlertBarContainer` placeholder.
+- **Props / variants:** extends `Notification` (severity: `success` | `error` | `warning` | `info`, message); `title?`, `disableTeleport?`. Emits `close`. Slots: `left` (icon override), default.
+- **Used for:** Page-level status messages (success/error/warning/info) below the header.
+
+## AlertBarContainer
+- **Location:** components/AlertBarContainer.vue
+- **Purpose:** Teleport target (`alert-bar="main"`) where AlertBar instances render, with `aria-live="assertive"`.
+- **Props / variants:** none.
+- **Used for:** Mounted once in the layout to host alert bars.
+
+## App404
+- **Location:** components/App404.vue
+- **Purpose:** Localized 404 page content, a thin wrapper around `AppError`.
+- **Props / variants:** none (uses i18n keys internally).
+- **Used for:** Not-found routes and missing content.
+
+## AppBackground
+- **Location:** components/AppBackground.vue
+- **Purpose:** Page background wrapper that sets background and default text colors including dark mode.
+- **Props / variants:** `background?: 'white' | 'gray'` (default `white`).
+- **Used for:** Root wrapper in app.vue; per-page gray background via app.config.ts.
+
+## AppButton
+- **Location:** components/AppButton.vue
+- **Purpose:** Minimal unstyled button wrapper (cursor + click emit).
+- **Props / variants:** none; emits `click`. Default slot.
+- **Used for:** Icon buttons like ColorModeSwitcher and mobile menu toggles.
+
+## AppChip
+- **Location:** components/AppChip.vue
+- **Purpose:** Small rounded-full pill label.
+- **Props / variants:** none; default slot; appearance composed by parent (see ChipLink).
+- **Used for:** Technology tags, category labels.
+
+## AppError
+- **Location:** components/AppError.vue
+- **Purpose:** Large error screen (big title, subtitle, description, back link) that also sets SEO meta.
+- **Props / variants:** `title?`, `subTitle?`, `description?`, `linkText?`, `linkLocation?`.
+- **Used for:** 404 and generic error pages (error.vue, App404).
+
+## AppFooter
+- **Location:** components/AppFooter.vue
+- **Purpose:** Site footer with about text, avatar, and social links; supports a short variant.
+- **Props / variants:** `title?`, `short?`, `linkedInUrl?`, `githubUrl?`, `imgSrc?`, `imgAlt?`, `backgroundColor?: 'white' | 'gray'`. Slot: `about`.
+- **Used for:** Global footer, mounted via AppFooterContext.
+
+## AppHeader
+- **Location:** components/AppHeader.vue
+- **Purpose:** Sticky site header with logo, navigation, mobile menu, color mode and language switchers; shrinks on scroll.
+- **Props / variants:** `border?`, `navigation?: NavigationItem[]`, `notifications?`, `colorMode?`, `language?`. Emits `update:colorMode`, `update:language`.
+- **Used for:** Global navigation, mounted via AppHeaderContext.
+
+## AppHero
+- **Location:** components/AppHero.vue
+- **Purpose:** Hero section with intro line (accent color), title, subtitle, prose text, and round profile image.
+- **Props / variants:** `intro?`, `title?`, `subTitle?`, `text?`, `imgSrc?`, `imgAlt?`. Default slot for prose body.
+- **Used for:** Home page and landing sections.
+
+## AppIcon
+- **Location:** components/AppIcon.vue
+- **Purpose:** Inline SVG brand icons.
+- **Props / variants:** `icon: 'X' | 'Linkedin' | 'Whatsapp' | 'Email' | 'GitHub'`.
+- **Used for:** ShareOn buttons and footer social links.
+
+## AppImage
+- **Location:** components/AppImage.vue
+- **Purpose:** Thin wrapper around NuxtImg.
+- **Props / variants:** `src?`, `alt?`, `width?`, `height?`, `sizes?`, `class?`, `loading?: 'lazy' | 'eager'`.
+- **Used for:** Simple images like the header logo; prefer ResponsiveImage for content images.
+
+## AppLink
+- **Location:** components/AppLink.vue
+- **Purpose:** Locale-aware link (NuxtLinkLocale) with gradient text color variants; renders a span when `to` is empty.
+- **Props / variants:** `to?`, `text?`, `color?: 'gray' | 'blue' | 'default'`, `target?`, `title?`, `ariaLabel?` (sets `rel="noopener"` for `_blank`).
+- **Used for:** All internal and external links.
+
+## AppMarkdown
+- **Location:** components/AppMarkdown.vue
+- **Purpose:** Renders a markdown string to HTML (v-html) with list bullets restored.
+- **Props / variants:** `text?: string`.
+- **Used for:** Markdown fields inside structured data, e.g. CV descriptions.
+
+## AppProse
+- **Location:** components/AppProse.vue
+- **Purpose:** Typography wrapper applying the project prose style (`prose prose-custom max-w-prose dark:prose-invert lg:prose-lg`).
+- **Props / variants:** none; default slot.
+- **Used for:** All long-form content: blog posts, hero text, page content.
+
+## AppTransition
+- **Location:** components/AppTransition.vue
+- **Purpose:** Named Vue transition wrapper with predefined animations.
+- **Props / variants:** `name: 'slide-up'`.
+- **Used for:** Icon swaps like ColorModeSwitcher.
+
+## AuthorInformation
+- **Location:** components/AuthorInformation.vue
+- **Purpose:** Author byline: avatar, linked name, LinkedIn, role/metadata line.
+- **Props / variants:** `fullName?`, `role?`, `imageUrl?`, `homePage?`, `linkedIn?`. Slots: `topLine`, `bottomLine`.
+- **Used for:** Blog post header and post summaries.
+
+## BlogPost
+- **Location:** components/BlogPost.vue
+- **Purpose:** Full blog post article: title, author, read stats, share buttons, rendered content.
+- **Props / variants:** `post?: BlogPost` (undefined while loading), `baseUrl: string`, `pageReads?: PageReads`.
+- **Used for:** Blog post detail page.
+
+## BlogPostSummary
+- **Location:** components/BlogPostSummary.vue
+- **Purpose:** Post card for list views: image, date, title, excerpt, author.
+- **Props / variants:** `post: BlogPostSummary`.
+- **Used for:** Blog listing pages.
+
+## BlogPosts
+- **Location:** components/BlogPosts.vue
+- **Purpose:** Grid/list layout wrapper for post summaries with top border.
+- **Props / variants:** none; default slot.
+- **Used for:** Wrapping a list of BlogPostSummary items.
+
+## ChipLink
+- **Location:** components/ChipLink.vue
+- **Purpose:** AppChip wrapped in AppLink with the standard gray gradient chip styling.
+- **Props / variants:** same props as AppLink (`to`, `text`, `target`, ...). Default slot.
+- **Used for:** Clickable tags, e.g. technology chips in the CV linking to related posts.
+
+## ColorModeSwitcher
+- **Location:** components/ColorModeSwitcher.vue
+- **Purpose:** Cycles color mode system → dark → light with animated icon swap (client-only).
+- **Props / variants:** `colorMode?: 'light' | 'dark' | 'system'` (default `system`). Emits `update:colorMode`.
+- **Used for:** Header color mode toggle.
+
+## CurriculumVitaeTable
+- **Location:** components/CurriculumVitaeTable.vue
+- **Purpose:** CV timeline: date column plus title/company, markdown description, and technology chips per entry.
+- **Props / variants:** `curriculumVitae?: CurriculumVitaeItem[]`.
+- **Used for:** The CV/resume page.
+
+## LanguageSwitcher
+- **Location:** components/LanguageSwitcher.vue
+- **Purpose:** Locale dropdown for the five supported locales.
+- **Props / variants:** `language?: LocalesCode` (default is the default locale). Emits `update:language`.
+- **Used for:** Header language selection.
+
+## NotificationContainer
+- **Location:** components/NotificationContainer.vue
+- **Purpose:** Fixed, full-screen teleport target (`notification="main"`) for toast notifications, with `aria-live="assertive"`.
+- **Props / variants:** none.
+- **Used for:** Mounted once in the layout to host NotificationMessage toasts.
+
+## NotificationMessage
+- **Location:** components/NotificationMessage.vue
+- **Purpose:** Toast notification that teleports into NotificationContainer.
+- **Props / variants:** extends `Notification` (severity, title, message); `disableTeleport?`.
+- **Used for:** Transient feedback messages.
+
+## PageContent
+- **Location:** components/PageContent.vue
+- **Purpose:** Standard page gutter wrapper (`px-4 lg:px-6`) with centered inner container; passes attrs to the inner div.
+- **Props / variants:** none; default slot.
+- **Used for:** Consistent horizontal padding for page sections and the footer.
+
+## PortfolioGrid
+- **Location:** components/PortfolioGrid.vue
+- **Purpose:** Full-width gray band with a responsive card grid of portfolio items (hover dims siblings).
+- **Props / variants:** `portfolio?: PortfolioItem[]` (items carry title, description, image, link, and grid placement classes).
+- **Used for:** Portfolio section on the home/CV page.
+
+## ResponsiveImage
+- **Location:** components/ResponsiveImage.vue
+- **Purpose:** Responsive image with per-breakpoint sizing (`partOfScreen*` fractions) and per-breakpoint aspect ratios; optional caption. The default choice for content images.
+- **Props / variants:** `src?`, `alt?`, `caption?`, `partOfScreen`/`partOfScreenExtraSmall`…`partOfScreen2ExtraLarge` (fraction of viewport width per breakpoint), `aspectRatio`/`aspectRatioExtraSmall`…`aspectRatio2ExtraLarge`.
+- **Used for:** Blog post images, avatars, portfolio images.
+
+## ShareOn
+- **Location:** components/ShareOn.vue
+- **Purpose:** Row of round social share buttons (X, LinkedIn, WhatsApp, Email) with prefilled share URLs.
+- **Props / variants:** `url: string`, `text?`, `icons?: Icon[]` (defaults to all four).
+- **Used for:** Sharing blog posts.
+
+## Content components (MDC, global in markdown)
+
+## CodeGroup
+- **Location:** components/content/CodeGroup.vue
+- **Purpose:** Tabbed group of code blocks inside markdown content.
+- **Props / variants:** used as `::code-group` MDC block.
+- **Used for:** Multi-language / multi-file code samples in posts.
+
+## PageReadProgress
+- **Location:** components/content/PageReadProgress.vue
+- **Purpose:** Reading progress indicator for content pages.
+- **Props / variants:** used from markdown content.
+- **Used for:** Blog posts.
+
+## PostImage
+- **Location:** components/content/PostImage.vue
+- **Purpose:** Image component for markdown posts (wraps responsive image behavior for content).
+- **Props / variants:** used as MDC component in posts.
+- **Used for:** Images inside post markdown.
+
+## Context layer (smart components/composables, `src/app/contexts/`)
+
+Not presentational; listed for orientation. All data fetching and shared state belongs here (see CLAUDE.md).
+
+- **AppHeaderContext.vue** — fetches navigation/notifications, wires color mode and language state into AppHeader.
+- **AppFooterContext.vue** — provides footer data to AppFooter.
+- **useAuthorsContext.ts** — queries `authors_{locale}` collections.
+- **useBlogPostsContext.ts** — queries `posts_{locale}`, joins author data into posts.
+- **useContentNavigationContext.ts** — builds navigation from content.
+- **usePageReadsContext.ts** — fetches page read statistics from the backend API.
+- **usePagesContext.ts** — queries `pages_{locale}` collections.

--- a/docs/design/tokens.css
+++ b/docs/design/tokens.css
@@ -1,0 +1,132 @@
+/**
+ * Design tokens for bach.software
+ * =============================================================================
+ * This file is consumed by the ui-designer agent to keep HTML prototypes
+ * consistent with the real application. Inline these custom properties in the
+ * prototype's <style> block and use them (or the matching Tailwind utilities)
+ * instead of inventing new values.
+ *
+ * SOURCE OF TRUTH: this project uses Tailwind CSS v4 (CSS-based config in
+ * src/app/assets/css/tailwind.css). It deliberately relies on the Tailwind v4
+ * DEFAULT theme for spacing, typography scale, radii, shadows, and
+ * breakpoints; the only theme extensions are the em-based text sizes below.
+ * Where a category is "Tailwind default", that is a documented fact about the
+ * app, not a gap in this file. Do not invent replacement values.
+ *
+ * Colors come from the Tailwind default palette (gray, slate, stone, sky,
+ * plus the alert colors). Tailwind v4 defines them in oklch; the hex values
+ * below are the standard close equivalents, good enough for prototypes.
+ * Dark mode is class-based: `html.dark` (custom variant in tailwind.css),
+ * with `color-scheme: dark` set globally in app.vue.
+ */
+
+:root {
+  /* ==========================================================================
+   * Colors — semantic (light mode value / see dark section below)
+   * ======================================================================== */
+
+  /* Page backgrounds (AppBackground variants: 'white' | 'gray') */
+  --color-bg-page: #ffffff;            /* bg-white */
+  --color-bg-page-alt: #f9fafb;        /* bg-gray-50 (gray background variant, portfolio band) */
+
+  /* Text */
+  --color-text-body: #374151;          /* text-gray-700 — default body text (AppBackground) */
+  --color-text-heading: #111827;       /* text-gray-900 — headings (AppHero h1, AppHeader) */
+  --color-text-secondary: #4b5563;     /* text-gray-600 — subtitles (AppHero h2) */
+  --color-text-muted: #6b7280;         /* text-gray-500 — dates, metadata, CV labels */
+
+  /* Accent — sky is the single accent color of the app (links, hero intro,
+     share buttons). Gradients go from the darker to the lighter shade. */
+  --color-accent: #0284c7;             /* sky-600 */
+  --color-accent-light: #0ea5e9;       /* sky-500 (gradient end, e.g. ShareOn, AppLink color="blue") */
+  --color-accent-hover: #0369a1;       /* sky-700 */
+
+  /* Alert / notification severities (AlertBar, NotificationMessage):
+     light bg + default text in light mode */
+  --color-alert-success-bg: #f0fdf4;   /* green-50 */
+  --color-alert-error-bg: #fef2f2;     /* red-50 */
+  --color-alert-warning-bg: #fefce8;   /* yellow-50 */
+  --color-alert-info-bg: #eff6ff;      /* blue-50 */
+
+  /* Borders and separators */
+  --color-border: #e5e7eb;             /* border-gray-200 (header border, blog post meta bar) */
+  --color-border-input: #e2e8f0;       /* slate-200 (form inputs in prose, main.scss) */
+
+  /* Code blocks (prose-custom utility in tailwind.css) */
+  --color-code-bg: #fafaf9;            /* stone-50 */
+  --color-code-text: #9ca3af;          /* gray-400 */
+  --color-code-highlight: #fefce8;     /* yellow-50 (shiki highlighted lines, main.scss) */
+
+  /* ==========================================================================
+   * Colors — dark mode (html.dark)
+   * The app does NOT use a plain inversion; these are the actual pairings.
+   * ======================================================================== */
+  --color-dark-bg-page: #0f172a;       /* dark:bg-slate-900 (white variant) */
+  --color-dark-bg-page-alt: #1f2937;   /* dark:bg-gray-800 (gray variant, alert bg) */
+  --color-dark-text-body: #d1d5db;     /* dark:text-gray-300 */
+  --color-dark-text-heading: #f9fafb;  /* dark:text-gray-50 */
+  --color-dark-text-secondary: #9ca3af;/* dark:text-gray-400 */
+  --color-dark-accent: #38bdf8;        /* dark:text-sky-400 */
+  --color-dark-border: #6b7280;        /* dark:border-gray-500 */
+  --color-dark-code-bg: #334155;       /* slate-700 (prose-invert pre bg) */
+  --color-dark-input-bg: #475569;      /* slate-600 (form inputs) */
+
+  /* ==========================================================================
+   * Typography
+   * Font family: Tailwind default sans stack — NO custom webfont is loaded.
+   * ======================================================================== */
+  --font-sans: ui-sans-serif, system-ui, sans-serif, 'Apple Color Emoji',
+    'Segoe UI Emoji', 'Segoe UI Symbol', 'Noto Color Emoji';
+
+  /* Type scale: Tailwind v4 defaults (text-xs 0.75rem ... text-4xl 2.25rem).
+     Project extensions from src/app/assets/css/tailwind.css — em-based sizes
+     that scale with the parent (used inside prose, e.g. BlogPostSummary): */
+  --text-xs-em: 0.75em;
+  --text-sm-em: 0.875em;
+
+  /* Weights actually used: font-medium (500) for headings-in-prose and
+     emphasis, font-semibold (600) for author names / error titles. Long-form
+     content uses the @tailwindcss/typography plugin via AppProse
+     (prose prose-custom max-w-prose dark:prose-invert lg:prose-lg,
+     prose-h1:font-medium). */
+
+  /* ==========================================================================
+   * Spacing
+   * Tailwind v4 default scale (base --spacing: 0.25rem). No custom values.
+   * Common rhythms in this app: p-4/px-4 lg:px-6 (PageContent gutters),
+   * py-12 lg:py-20 (footer), py-24 lg:py-28 (hero), gap-4/gap-8/gap-12.
+   * ======================================================================== */
+  --spacing: 0.25rem;
+
+  /* ==========================================================================
+   * Border radii — Tailwind defaults; the ones this app actually uses:
+   * ======================================================================== */
+  --radius-input: 4px;                 /* form inputs in prose (main.scss) */
+  --radius-lg: 0.5rem;                 /* rounded-lg — portfolio cards */
+  --radius-2xl: 1rem;                  /* rounded-2xl — blog post images */
+  --radius-full: calc(infinity * 1px); /* rounded-full — chips, avatars, share buttons */
+
+  /* ==========================================================================
+   * Shadows — Tailwind defaults; the ones this app actually uses:
+   * shadow-sm + ring-1 ring-black/5 (portfolio cards, dark: ring-white/15),
+   * drop-shadow-md (blog post summary images).
+   * ======================================================================== */
+  --shadow-card: 0 1px 3px 0 rgb(0 0 0 / 0.1), 0 1px 2px -1px rgb(0 0 0 / 0.1);
+  --ring-card: 0 0 0 1px rgb(0 0 0 / 0.05);
+
+  /* ==========================================================================
+   * Breakpoints — Tailwind v4 defaults (no customization). The app designs
+   * mostly with max-md (stacking) and lg (desktop layout).
+   * ======================================================================== */
+  --breakpoint-sm: 40rem;   /* 640px */
+  --breakpoint-md: 48rem;   /* 768px */
+  --breakpoint-lg: 64rem;   /* 1024px */
+  --breakpoint-xl: 80rem;   /* 1280px */
+  --breakpoint-2xl: 96rem;  /* 1536px */
+
+  /* ==========================================================================
+   * Layout containers
+   * ======================================================================== */
+  --container-page: 80rem;  /* max-w-7xl — header nav width */
+  --container-prose: 65ch;  /* max-w-prose — article/content column */
+}

--- a/docs/design/tokens.css
+++ b/docs/design/tokens.css
@@ -26,57 +26,57 @@
    * ======================================================================== */
 
   /* Page backgrounds (AppBackground variants: 'white' | 'gray') */
-  --color-bg-page: #ffffff;            /* bg-white */
-  --color-bg-page-alt: #f9fafb;        /* bg-gray-50 (gray background variant, portfolio band) */
+  --color-bg-page: #ffffff; /* bg-white */
+  --color-bg-page-alt: #f9fafb; /* bg-gray-50 (gray background variant, portfolio band) */
 
   /* Text */
-  --color-text-body: #374151;          /* text-gray-700 — default body text (AppBackground) */
-  --color-text-heading: #111827;       /* text-gray-900 — headings (AppHero h1, AppHeader) */
-  --color-text-secondary: #4b5563;     /* text-gray-600 — subtitles (AppHero h2) */
-  --color-text-muted: #6b7280;         /* text-gray-500 — dates, metadata, CV labels */
+  --color-text-body: #374151; /* text-gray-700, default body text (AppBackground) */
+  --color-text-heading: #111827; /* text-gray-900, headings (AppHero h1, AppHeader) */
+  --color-text-secondary: #4b5563; /* text-gray-600, subtitles (AppHero h2) */
+  --color-text-muted: #6b7280; /* text-gray-500, dates, metadata, CV labels */
 
-  /* Accent — sky is the single accent color of the app (links, hero intro,
+  /* Accent: sky is the single accent color of the app (links, hero intro,
      share buttons). Gradients go from the darker to the lighter shade. */
-  --color-accent: #0284c7;             /* sky-600 */
-  --color-accent-light: #0ea5e9;       /* sky-500 (gradient end, e.g. ShareOn, AppLink color="blue") */
-  --color-accent-hover: #0369a1;       /* sky-700 */
+  --color-accent: #0284c7; /* sky-600 */
+  --color-accent-light: #0ea5e9; /* sky-500 (gradient end, e.g. ShareOn, AppLink color="blue") */
+  --color-accent-hover: #0369a1; /* sky-700 */
 
   /* Alert / notification severities (AlertBar, NotificationMessage):
      light bg + default text in light mode */
-  --color-alert-success-bg: #f0fdf4;   /* green-50 */
-  --color-alert-error-bg: #fef2f2;     /* red-50 */
-  --color-alert-warning-bg: #fefce8;   /* yellow-50 */
-  --color-alert-info-bg: #eff6ff;      /* blue-50 */
+  --color-alert-success-bg: #f0fdf4; /* green-50 */
+  --color-alert-error-bg: #fef2f2; /* red-50 */
+  --color-alert-warning-bg: #fefce8; /* yellow-50 */
+  --color-alert-info-bg: #eff6ff; /* blue-50 */
 
   /* Borders and separators */
-  --color-border: #e5e7eb;             /* border-gray-200 (header border, blog post meta bar) */
-  --color-border-input: #e2e8f0;       /* slate-200 (form inputs in prose, main.scss) */
+  --color-border: #e5e7eb; /* border-gray-200 (header border, blog post meta bar) */
+  --color-border-input: #e2e8f0; /* slate-200 (form inputs in prose, main.scss) */
 
   /* Code blocks (prose-custom utility in tailwind.css) */
-  --color-code-bg: #fafaf9;            /* stone-50 */
-  --color-code-text: #9ca3af;          /* gray-400 */
-  --color-code-highlight: #fefce8;     /* yellow-50 (shiki highlighted lines, main.scss) */
+  --color-code-bg: #fafaf9; /* stone-50 */
+  --color-code-text: #9ca3af; /* gray-400 */
+  --color-code-highlight: #fefce8; /* yellow-50 (shiki highlighted lines, main.scss) */
 
   /* ==========================================================================
    * Colors — dark mode (html.dark)
    * The app does NOT use a plain inversion; these are the actual pairings.
    * ======================================================================== */
-  --color-dark-bg-page: #0f172a;       /* dark:bg-slate-900 (white variant) */
-  --color-dark-bg-page-alt: #1f2937;   /* dark:bg-gray-800 (gray variant, alert bg) */
-  --color-dark-text-body: #d1d5db;     /* dark:text-gray-300 */
-  --color-dark-text-heading: #f9fafb;  /* dark:text-gray-50 */
-  --color-dark-text-secondary: #9ca3af;/* dark:text-gray-400 */
-  --color-dark-accent: #38bdf8;        /* dark:text-sky-400 */
-  --color-dark-border: #6b7280;        /* dark:border-gray-500 */
-  --color-dark-code-bg: #334155;       /* slate-700 (prose-invert pre bg) */
-  --color-dark-input-bg: #475569;      /* slate-600 (form inputs) */
+  --color-dark-bg-page: #0f172a; /* dark:bg-slate-900 (white variant) */
+  --color-dark-bg-page-alt: #1f2937; /* dark:bg-gray-800 (gray variant, alert bg) */
+  --color-dark-text-body: #d1d5db; /* dark:text-gray-300 */
+  --color-dark-text-heading: #f9fafb; /* dark:text-gray-50 */
+  --color-dark-text-secondary: #9ca3af; /* dark:text-gray-400 */
+  --color-dark-accent: #38bdf8; /* dark:text-sky-400 */
+  --color-dark-border: #6b7280; /* dark:border-gray-500 */
+  --color-dark-code-bg: #334155; /* slate-700 (prose-invert pre bg) */
+  --color-dark-input-bg: #475569; /* slate-600 (form inputs) */
 
   /* ==========================================================================
    * Typography
    * Font family: Tailwind default sans stack — NO custom webfont is loaded.
    * ======================================================================== */
-  --font-sans: ui-sans-serif, system-ui, sans-serif, 'Apple Color Emoji',
-    'Segoe UI Emoji', 'Segoe UI Symbol', 'Noto Color Emoji';
+  --font-sans:
+    ui-sans-serif, system-ui, sans-serif, 'Apple Color Emoji', 'Segoe UI Emoji', 'Segoe UI Symbol', 'Noto Color Emoji';
 
   /* Type scale: Tailwind v4 defaults (text-xs 0.75rem ... text-4xl 2.25rem).
      Project extensions from src/app/assets/css/tailwind.css — em-based sizes
@@ -101,10 +101,10 @@
   /* ==========================================================================
    * Border radii — Tailwind defaults; the ones this app actually uses:
    * ======================================================================== */
-  --radius-input: 4px;                 /* form inputs in prose (main.scss) */
-  --radius-lg: 0.5rem;                 /* rounded-lg — portfolio cards */
-  --radius-2xl: 1rem;                  /* rounded-2xl — blog post images */
-  --radius-full: calc(infinity * 1px); /* rounded-full — chips, avatars, share buttons */
+  --radius-input: 4px; /* form inputs in prose (main.scss) */
+  --radius-lg: 0.5rem; /* rounded-lg, portfolio cards */
+  --radius-2xl: 1rem; /* rounded-2xl, blog post images */
+  --radius-full: calc(infinity * 1px); /* rounded-full, chips, avatars, share buttons */
 
   /* ==========================================================================
    * Shadows — Tailwind defaults; the ones this app actually uses:
@@ -118,15 +118,15 @@
    * Breakpoints — Tailwind v4 defaults (no customization). The app designs
    * mostly with max-md (stacking) and lg (desktop layout).
    * ======================================================================== */
-  --breakpoint-sm: 40rem;   /* 640px */
-  --breakpoint-md: 48rem;   /* 768px */
-  --breakpoint-lg: 64rem;   /* 1024px */
-  --breakpoint-xl: 80rem;   /* 1280px */
-  --breakpoint-2xl: 96rem;  /* 1536px */
+  --breakpoint-sm: 40rem; /* 640px */
+  --breakpoint-md: 48rem; /* 768px */
+  --breakpoint-lg: 64rem; /* 1024px */
+  --breakpoint-xl: 80rem; /* 1280px */
+  --breakpoint-2xl: 96rem; /* 1536px */
 
   /* ==========================================================================
    * Layout containers
    * ======================================================================== */
-  --container-page: 80rem;  /* max-w-7xl — header nav width */
-  --container-prose: 65ch;  /* max-w-prose — article/content column */
+  --container-page: 80rem; /* max-w-7xl, header nav width */
+  --container-prose: 65ch; /* max-w-prose, article/content column */
 }

--- a/docs/specs/README.md
+++ b/docs/specs/README.md
@@ -1,0 +1,76 @@
+# Spec-driven development workflow
+
+All feature and story specs live in this folder. The workflow is built on one core principle: **design and architecture happen at FEATURE level** so the result is cohesive. Stories are delivery slices carved out of an already-designed feature; they reference the feature-level design and architecture instead of producing their own. Splitting happens AFTER architecture, so stories reflect real dependencies and component boundaries.
+
+## Lifecycles
+
+Feature lifecycle (design and architecture live here):
+
+```
+draft → design → architecture → adversarial-review → awaiting-approval → approved → in-progress → done
+```
+
+Story lifecycle (stories are created only after the feature is approved):
+
+```
+draft → qa → adversarial-review → awaiting-approval → approved → implementing → verifying → done
+```
+
+Quick lane (bug fixes and trivial changes):
+
+```
+draft → adversarial-review → awaiting-approval → approved → implementing → done
+```
+
+## Approval gates
+
+There are two gates, and both belong to Jeroen alone:
+
+1. **Feature direction** — a feature must be `approved` before the scrum-master may split it into stories.
+2. **Story implementation** — a story must be `approved` before the developer may implement it.
+
+Only Jeroen may set `status: approved` and fill `approved_by`, on features AND stories. No agent ever sets, suggests setting, or works past this gate. A spec in `awaiting-approval` is waiting for Jeroen; the only valid agent action is to report and stop. Each agent advances the status only for its own phase, and only after completing its section. Story-level changes that contradict the approved feature design or architecture require amending the feature spec first (which flags it for Jeroen), never a silent local override.
+
+## Command reference (in workflow order)
+
+| Command | What it does |
+| --- | --- |
+| `/spec:feature <idea>` | Product-owner creates the feature spec |
+| `/spec:design FEAT-XXX` | Ui-designer builds the cohesive prototype for the whole feature |
+| `/spec:arch FEAT-XXX` | Architect works out the complete technical design |
+| `/spec:review FEAT-XXX` | Adversarial-reviewer attacks the spec (full mode) |
+| **APPROVE** | Jeroen reviews and sets `status: approved` on the feature |
+| `/spec:split FEAT-XXX` | Scrum-master slices the approved feature into stories |
+| Per story: `/spec:qa ST-YY` | Qa-planner writes the test plan |
+| Per story: `/spec:review ST-YY` | Adversarial-reviewer, lite mode |
+| **APPROVE** | Jeroen sets `status: approved` on the story |
+| `/spec:implement ST-YY` | Developer implements the approved story |
+| `/spec:verify ST-YY` | Qa-verifier checks the implementation against spec and prototype |
+| `/spec:quick <description>` | Fast lane for bug fixes and trivial changes |
+| `/spec:status` | Show all specs and their current status |
+
+## Folder structure
+
+```
+docs/specs/
+  README.md                          # this file
+  TEMPLATE-feature.md
+  TEMPLATE-story.md
+  FEAT-XXX-<kebab-name>/
+    spec.md                          # the feature spec
+    prototype.html                   # cohesive prototype of the entire feature
+    assets/                          # screenshots, mockups, sketches
+    stories/
+      ST-YY-<kebab-name>/
+        spec.md                      # the story spec (thin: references the feature)
+  QUICK-XXX-<kebab-name>/
+    spec.md                          # quick-lane mini spec
+```
+
+## Quick lane
+
+For bug fixes and trivial changes, `/spec:quick` creates a `QUICK-XXX-<name>/spec.md` mini spec (problem, proposed change, affected files, test impact), runs a lite adversarial review, and stops at `awaiting-approval` for Jeroen. After approval, `/spec:implement` works on quick specs too, including the components.md and Tailwind rules.
+
+## Work item convention
+
+Jira/work items only carry a link to the spec folder and the PR. The spec is the single source of truth; nothing is duplicated into work item descriptions.

--- a/docs/specs/TEMPLATE-feature.md
+++ b/docs/specs/TEMPLATE-feature.md
@@ -1,0 +1,36 @@
+---
+id: FEAT-000
+type: feature
+status: draft
+created: YYYY-MM-DD
+approved_by: ""
+---
+
+# Feature: <name>
+
+## Problem & goal
+What problem this solves and for whom. What success looks like.
+
+## Scope
+### In scope
+### Out of scope (explicit)
+
+## Functional overview
+User-facing behavior, main flows.
+
+## Design (feature level)
+Filled by ui-designer. Link to `prototype.html` (the cohesive prototype of the ENTIRE feature) and `assets/`. Design language decisions, layout system, states policy (loading, empty, error handled consistently across the feature), responsive strategy. Each screen/section in the prototype has an HTML anchor id so stories can deep-link to their slice.
+
+## Architecture (feature level)
+Filled by architect. The complete technical design: component plan for the whole feature (reuse / modify / new, referencing docs/components.md), component APIs with variants, full API contract (Kiota client impact, C# endpoints), data flow and composables, Nuxt SSR/client boundaries, Mermaid diagrams, ADR-style notes for every real decision.
+
+## Adversarial review
+Filled by adversarial-reviewer at feature level. Findings and resolutions.
+
+## Constraints & assumptions
+
+## Open questions
+Questions for Jeroen. Must be resolved before approval.
+
+## Stories
+Filled by scrum-master AFTER approval. Links to story folders with implementation order and dependency notes.

--- a/docs/specs/TEMPLATE-story.md
+++ b/docs/specs/TEMPLATE-story.md
@@ -1,0 +1,37 @@
+---
+id: ST-00
+type: story
+feature: FEAT-000
+status: draft
+created: YYYY-MM-DD
+approved_by: ""
+pr: ""
+---
+
+# Story: <name>
+
+## Functional
+### User story
+As a ..., I want ..., so that ...
+### Acceptance criteria
+Given/When/Then format. Each criterion independently verifiable.
+### Edge cases
+### Out of scope
+
+## Design reference
+Link to the feature prototype anchor(s) this story implements (e.g. `../../prototype.html#detail-panel`). Only DELTAS go here: refinements or details the feature-level design left open for this slice. No new design language.
+
+## Architecture reference
+Which parts of the feature architecture this story implements: components to build/modify in this slice, endpoints touched, dependencies on other stories. Only DELTAS beyond the feature architecture are worked out here. A story that needs to overturn a feature-level decision does not do so silently: it flags the conflict, and the feature spec gets amended first.
+
+## QA plan
+Filled by qa-planner. Test plan mapped to the project's testing strategy: what gets unit tests vs. component tests, fixtures to use, regression risks, manual verification steps.
+
+## Adversarial review
+Filled by adversarial-reviewer (lite, story level). Findings and resolutions.
+
+## Implementation notes
+Filled by developer during implementation: deviations from plan and why. Deviations that affect the feature design/architecture are also propagated to the feature spec.
+
+## Verification report
+Filled by qa-verifier after implementation.

--- a/package.json
+++ b/package.json
@@ -112,6 +112,7 @@
     "vue": "3.5.35",
     "vue-i18n": "11.4.4",
     "vue-i18n-extract": "2.0.7",
+    "vue-tsc": "3.3.6",
     "xml-formatter": "3.7.0",
     "yaml": "2.9.0"
   }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -137,7 +137,7 @@ importers:
         version: 18.0.4
       nuxt:
         specifier: 4.4.6
-        version: 4.4.6(@babel/plugin-proposal-decorators@7.29.7(@babel/core@7.29.7))(@babel/plugin-syntax-jsx@7.29.7(@babel/core@7.29.7))(@babel/plugin-syntax-typescript@7.29.7(@babel/core@7.29.7))(@parcel/watcher@2.5.6)(@types/node@25.9.1)(@vue/compiler-sfc@3.5.38)(better-sqlite3@12.10.0)(cac@6.7.14)(db0@0.3.4(better-sqlite3@12.10.0))(eslint@10.4.0(jiti@2.7.0))(ioredis@5.11.1)(lightningcss@1.32.0)(magicast@0.5.3)(optionator@0.9.4)(pinia@3.0.4(typescript@6.0.3)(vue@3.5.35(typescript@6.0.3)))(rolldown@1.0.2)(rollup-plugin-visualizer@7.0.1(rolldown@1.0.2)(rollup@4.62.0))(rollup@4.62.0)(sass@1.100.0)(srvx@0.11.16)(terser@5.48.0)(typescript@6.0.3)(vite@8.0.14(@types/node@25.9.1)(esbuild@0.28.1)(jiti@2.7.0)(sass@1.100.0)(terser@5.48.0)(yaml@2.9.0))(yaml@2.9.0)
+        version: 4.4.6(@babel/plugin-proposal-decorators@7.29.7(@babel/core@7.29.7))(@babel/plugin-syntax-jsx@7.29.7(@babel/core@7.29.7))(@babel/plugin-syntax-typescript@7.29.7(@babel/core@7.29.7))(@parcel/watcher@2.5.6)(@types/node@25.9.1)(@vue/compiler-sfc@3.5.38)(better-sqlite3@12.10.0)(cac@6.7.14)(db0@0.3.4(better-sqlite3@12.10.0))(eslint@10.4.0(jiti@2.7.0))(ioredis@5.11.1)(lightningcss@1.32.0)(magicast@0.5.3)(optionator@0.9.4)(pinia@3.0.4(typescript@6.0.3)(vue@3.5.35(typescript@6.0.3)))(rolldown@1.0.2)(rollup-plugin-visualizer@7.0.1(rolldown@1.0.2)(rollup@4.62.0))(rollup@4.62.0)(sass@1.100.0)(srvx@0.11.16)(terser@5.48.0)(typescript@6.0.3)(vite@8.0.14(@types/node@25.9.1)(esbuild@0.28.1)(jiti@2.7.0)(sass@1.100.0)(terser@5.48.0)(yaml@2.9.0))(vue-tsc@3.3.6(typescript@6.0.3))(yaml@2.9.0)
       playwright-core:
         specifier: 1.60.0
         version: 1.60.0
@@ -189,6 +189,9 @@ importers:
       vue-i18n-extract:
         specifier: 2.0.7
         version: 2.0.7
+      vue-tsc:
+        specifier: 3.3.6
+        version: 3.3.6(typescript@6.0.3)
       xml-formatter:
         specifier: 3.7.0
         version: 3.7.0
@@ -3829,6 +3832,9 @@ packages:
 
   '@vue/language-core@3.3.5':
     resolution: {integrity: sha512-UkKu5nhX89fg4VhlG/FOeI10G3cj/7radKT/cy9BT4Q9qJmJlSTAc/dP63Xqs29aypN4f39xUV6PsLNk/dcD6g==}
+
+  '@vue/language-core@3.3.6':
+    resolution: {integrity: sha512-LgBMZAy2sR3cQWknpyaxnI6yBkqDfLBPkbdhwRhQCvzfNJRQXPilgQIrdI/v4ytJ0sAq9bWhaPsjqBqneomJ3Q==}
 
   '@vue/reactivity@3.5.35':
     resolution: {integrity: sha512-tVc+SsHConvh/Lz64qq1pP3rYArBmK42xonovEcxY74SQtvctZodG/zhq54P5dr38cVuw25d27cPNRdlMidpGQ==}
@@ -8113,6 +8119,12 @@ packages:
       vite:
         optional: true
 
+  vue-tsc@3.3.6:
+    resolution: {integrity: sha512-ERXGgbKSBGFUkavrJ1Iwj0ZVxKqB/5UOx65IXy7fPf2UsoI21n3ssQLwdvx8xyUGgJe9PvSZTM/FYzIdwUDPFA==}
+    hasBin: true
+    peerDependencies:
+      typescript: '>=5.0.0'
+
   vue@3.5.35:
     resolution: {integrity: sha512-cx89fnr+0kVGHiNFG6y6s0bdjypJRFNZn6x3WPstNdQR1bi1mbB7h4v5IBGTsPJU3nK1+0Iqj3Zf+hZWMieR4Q==}
     peerDependencies:
@@ -9759,7 +9771,7 @@ snapshots:
     transitivePeerDependencies:
       - magicast
 
-  '@nuxt/nitro-server@4.4.6(e1596317a7a37abaa520f05c208dc911)':
+  '@nuxt/nitro-server@4.4.6(2fbed78165fd8e714631137dded36734)':
     dependencies:
       '@nuxt/devalue': 2.0.2
       '@nuxt/kit': 4.4.6(magicast@0.5.3)
@@ -9777,7 +9789,7 @@ snapshots:
       klona: 2.0.6
       mocked-exports: 0.1.1
       nitropack: 2.13.4(better-sqlite3@12.10.0)(oxc-parser@0.131.0)(rolldown@1.0.2)(srvx@0.11.16)
-      nuxt: 4.4.6(@babel/plugin-proposal-decorators@7.29.7(@babel/core@7.29.7))(@babel/plugin-syntax-jsx@7.29.7(@babel/core@7.29.7))(@babel/plugin-syntax-typescript@7.29.7(@babel/core@7.29.7))(@parcel/watcher@2.5.6)(@types/node@25.9.1)(@vue/compiler-sfc@3.5.38)(better-sqlite3@12.10.0)(cac@6.7.14)(db0@0.3.4(better-sqlite3@12.10.0))(eslint@10.4.0(jiti@2.7.0))(ioredis@5.11.1)(lightningcss@1.32.0)(magicast@0.5.3)(optionator@0.9.4)(pinia@3.0.4(typescript@6.0.3)(vue@3.5.35(typescript@6.0.3)))(rolldown@1.0.2)(rollup-plugin-visualizer@7.0.1(rolldown@1.0.2)(rollup@4.62.0))(rollup@4.62.0)(sass@1.100.0)(srvx@0.11.16)(terser@5.48.0)(typescript@6.0.3)(vite@8.0.14(@types/node@25.9.1)(esbuild@0.28.1)(jiti@2.7.0)(sass@1.100.0)(terser@5.48.0)(yaml@2.9.0))(yaml@2.9.0)
+      nuxt: 4.4.6(@babel/plugin-proposal-decorators@7.29.7(@babel/core@7.29.7))(@babel/plugin-syntax-jsx@7.29.7(@babel/core@7.29.7))(@babel/plugin-syntax-typescript@7.29.7(@babel/core@7.29.7))(@parcel/watcher@2.5.6)(@types/node@25.9.1)(@vue/compiler-sfc@3.5.38)(better-sqlite3@12.10.0)(cac@6.7.14)(db0@0.3.4(better-sqlite3@12.10.0))(eslint@10.4.0(jiti@2.7.0))(ioredis@5.11.1)(lightningcss@1.32.0)(magicast@0.5.3)(optionator@0.9.4)(pinia@3.0.4(typescript@6.0.3)(vue@3.5.35(typescript@6.0.3)))(rolldown@1.0.2)(rollup-plugin-visualizer@7.0.1(rolldown@1.0.2)(rollup@4.62.0))(rollup@4.62.0)(sass@1.100.0)(srvx@0.11.16)(terser@5.48.0)(typescript@6.0.3)(vite@8.0.14(@types/node@25.9.1)(esbuild@0.28.1)(jiti@2.7.0)(sass@1.100.0)(terser@5.48.0)(yaml@2.9.0))(vue-tsc@3.3.6(typescript@6.0.3))(yaml@2.9.0)
       nypm: 0.6.7
       ohash: 2.0.11
       pathe: 2.0.3
@@ -9891,7 +9903,7 @@ snapshots:
       - typescript
       - vite
 
-  '@nuxt/vite-builder@4.4.6(cd52aabbdf33577f9cc751387992a250)':
+  '@nuxt/vite-builder@4.4.6(8caa87b154805e344955b5d1a75cf5c8)':
     dependencies:
       '@nuxt/kit': 4.4.6(magicast@0.5.3)
       '@rollup/plugin-replace': 6.0.3(rollup@4.62.0)
@@ -9909,7 +9921,7 @@ snapshots:
       magic-string: 0.30.21
       mlly: 1.8.2
       mocked-exports: 0.1.1
-      nuxt: 4.4.6(@babel/plugin-proposal-decorators@7.29.7(@babel/core@7.29.7))(@babel/plugin-syntax-jsx@7.29.7(@babel/core@7.29.7))(@babel/plugin-syntax-typescript@7.29.7(@babel/core@7.29.7))(@parcel/watcher@2.5.6)(@types/node@25.9.1)(@vue/compiler-sfc@3.5.38)(better-sqlite3@12.10.0)(cac@6.7.14)(db0@0.3.4(better-sqlite3@12.10.0))(eslint@10.4.0(jiti@2.7.0))(ioredis@5.11.1)(lightningcss@1.32.0)(magicast@0.5.3)(optionator@0.9.4)(pinia@3.0.4(typescript@6.0.3)(vue@3.5.35(typescript@6.0.3)))(rolldown@1.0.2)(rollup-plugin-visualizer@7.0.1(rolldown@1.0.2)(rollup@4.62.0))(rollup@4.62.0)(sass@1.100.0)(srvx@0.11.16)(terser@5.48.0)(typescript@6.0.3)(vite@8.0.14(@types/node@25.9.1)(esbuild@0.28.1)(jiti@2.7.0)(sass@1.100.0)(terser@5.48.0)(yaml@2.9.0))(yaml@2.9.0)
+      nuxt: 4.4.6(@babel/plugin-proposal-decorators@7.29.7(@babel/core@7.29.7))(@babel/plugin-syntax-jsx@7.29.7(@babel/core@7.29.7))(@babel/plugin-syntax-typescript@7.29.7(@babel/core@7.29.7))(@parcel/watcher@2.5.6)(@types/node@25.9.1)(@vue/compiler-sfc@3.5.38)(better-sqlite3@12.10.0)(cac@6.7.14)(db0@0.3.4(better-sqlite3@12.10.0))(eslint@10.4.0(jiti@2.7.0))(ioredis@5.11.1)(lightningcss@1.32.0)(magicast@0.5.3)(optionator@0.9.4)(pinia@3.0.4(typescript@6.0.3)(vue@3.5.35(typescript@6.0.3)))(rolldown@1.0.2)(rollup-plugin-visualizer@7.0.1(rolldown@1.0.2)(rollup@4.62.0))(rollup@4.62.0)(sass@1.100.0)(srvx@0.11.16)(terser@5.48.0)(typescript@6.0.3)(vite@8.0.14(@types/node@25.9.1)(esbuild@0.28.1)(jiti@2.7.0)(sass@1.100.0)(terser@5.48.0)(yaml@2.9.0))(vue-tsc@3.3.6(typescript@6.0.3))(yaml@2.9.0)
       nypm: 0.6.7
       pathe: 2.0.3
       pkg-types: 2.3.1
@@ -9920,7 +9932,7 @@ snapshots:
       unenv: 2.0.0-rc.24
       vite: 7.3.5(@types/node@25.9.1)(jiti@2.7.0)(lightningcss@1.32.0)(sass@1.100.0)(terser@5.48.0)(yaml@2.9.0)
       vite-node: 5.3.0(@types/node@25.9.1)(jiti@2.7.0)(lightningcss@1.32.0)(sass@1.100.0)(terser@5.48.0)(yaml@2.9.0)
-      vite-plugin-checker: 0.13.0(eslint@10.4.0(jiti@2.7.0))(optionator@0.9.4)(typescript@6.0.3)(vite@7.3.5(@types/node@25.9.1)(jiti@2.7.0)(lightningcss@1.32.0)(sass@1.100.0)(terser@5.48.0)(yaml@2.9.0))
+      vite-plugin-checker: 0.13.0(eslint@10.4.0(jiti@2.7.0))(optionator@0.9.4)(typescript@6.0.3)(vite@7.3.5(@types/node@25.9.1)(jiti@2.7.0)(lightningcss@1.32.0)(sass@1.100.0)(terser@5.48.0)(yaml@2.9.0))(vue-tsc@3.3.6(typescript@6.0.3))
       vue: 3.5.35(typescript@6.0.3)
       vue-bundle-renderer: 2.2.0
     optionalDependencies:
@@ -11675,6 +11687,16 @@ snapshots:
       typescript: 5.9.3
 
   '@vue/language-core@3.3.5':
+    dependencies:
+      '@volar/language-core': 2.4.28
+      '@vue/compiler-dom': 3.5.38
+      '@vue/shared': 3.5.38
+      alien-signals: 3.2.1
+      muggle-string: 0.4.1
+      path-browserify: 1.0.1
+      picomatch: 4.0.4
+
+  '@vue/language-core@3.3.6':
     dependencies:
       '@volar/language-core': 2.4.28
       '@vue/compiler-dom': 3.5.38
@@ -14614,16 +14636,16 @@ snapshots:
 
   nuxt-define@1.0.0: {}
 
-  nuxt@4.4.6(@babel/plugin-proposal-decorators@7.29.7(@babel/core@7.29.7))(@babel/plugin-syntax-jsx@7.29.7(@babel/core@7.29.7))(@babel/plugin-syntax-typescript@7.29.7(@babel/core@7.29.7))(@parcel/watcher@2.5.6)(@types/node@25.9.1)(@vue/compiler-sfc@3.5.38)(better-sqlite3@12.10.0)(cac@6.7.14)(db0@0.3.4(better-sqlite3@12.10.0))(eslint@10.4.0(jiti@2.7.0))(ioredis@5.11.1)(lightningcss@1.32.0)(magicast@0.5.3)(optionator@0.9.4)(pinia@3.0.4(typescript@6.0.3)(vue@3.5.35(typescript@6.0.3)))(rolldown@1.0.2)(rollup-plugin-visualizer@7.0.1(rolldown@1.0.2)(rollup@4.62.0))(rollup@4.62.0)(sass@1.100.0)(srvx@0.11.16)(terser@5.48.0)(typescript@6.0.3)(vite@8.0.14(@types/node@25.9.1)(esbuild@0.28.1)(jiti@2.7.0)(sass@1.100.0)(terser@5.48.0)(yaml@2.9.0))(yaml@2.9.0):
+  nuxt@4.4.6(@babel/plugin-proposal-decorators@7.29.7(@babel/core@7.29.7))(@babel/plugin-syntax-jsx@7.29.7(@babel/core@7.29.7))(@babel/plugin-syntax-typescript@7.29.7(@babel/core@7.29.7))(@parcel/watcher@2.5.6)(@types/node@25.9.1)(@vue/compiler-sfc@3.5.38)(better-sqlite3@12.10.0)(cac@6.7.14)(db0@0.3.4(better-sqlite3@12.10.0))(eslint@10.4.0(jiti@2.7.0))(ioredis@5.11.1)(lightningcss@1.32.0)(magicast@0.5.3)(optionator@0.9.4)(pinia@3.0.4(typescript@6.0.3)(vue@3.5.35(typescript@6.0.3)))(rolldown@1.0.2)(rollup-plugin-visualizer@7.0.1(rolldown@1.0.2)(rollup@4.62.0))(rollup@4.62.0)(sass@1.100.0)(srvx@0.11.16)(terser@5.48.0)(typescript@6.0.3)(vite@8.0.14(@types/node@25.9.1)(esbuild@0.28.1)(jiti@2.7.0)(sass@1.100.0)(terser@5.48.0)(yaml@2.9.0))(vue-tsc@3.3.6(typescript@6.0.3))(yaml@2.9.0):
     dependencies:
       '@dxup/nuxt': 0.4.1(magicast@0.5.3)(typescript@6.0.3)
       '@nuxt/cli': 3.35.2(@nuxt/schema@4.4.6)(cac@6.7.14)(magicast@0.5.3)
       '@nuxt/devtools': 3.2.4(vite@8.0.14(@types/node@25.9.1)(esbuild@0.28.1)(jiti@2.7.0)(sass@1.100.0)(terser@5.48.0)(yaml@2.9.0))(vue@3.5.35(typescript@6.0.3))
       '@nuxt/kit': 4.4.6(magicast@0.5.3)
-      '@nuxt/nitro-server': 4.4.6(e1596317a7a37abaa520f05c208dc911)
+      '@nuxt/nitro-server': 4.4.6(2fbed78165fd8e714631137dded36734)
       '@nuxt/schema': 4.4.6
       '@nuxt/telemetry': 2.8.0(@nuxt/kit@4.4.6(magicast@0.5.3))
-      '@nuxt/vite-builder': 4.4.6(cd52aabbdf33577f9cc751387992a250)
+      '@nuxt/vite-builder': 4.4.6(8caa87b154805e344955b5d1a75cf5c8)
       '@unhead/vue': 2.1.15(vue@3.5.35(typescript@6.0.3))
       '@vue/shared': 3.5.38
       chokidar: 5.0.0
@@ -16603,7 +16625,7 @@ snapshots:
       - tsx
       - yaml
 
-  vite-plugin-checker@0.13.0(eslint@10.4.0(jiti@2.7.0))(optionator@0.9.4)(typescript@6.0.3)(vite@7.3.5(@types/node@25.9.1)(jiti@2.7.0)(lightningcss@1.32.0)(sass@1.100.0)(terser@5.48.0)(yaml@2.9.0)):
+  vite-plugin-checker@0.13.0(eslint@10.4.0(jiti@2.7.0))(optionator@0.9.4)(typescript@6.0.3)(vite@7.3.5(@types/node@25.9.1)(jiti@2.7.0)(lightningcss@1.32.0)(sass@1.100.0)(terser@5.48.0)(yaml@2.9.0))(vue-tsc@3.3.6(typescript@6.0.3)):
     dependencies:
       '@babel/code-frame': 7.29.7
       chokidar: 4.0.3
@@ -16619,6 +16641,7 @@ snapshots:
       eslint: 10.4.0(jiti@2.7.0)
       optionator: 0.9.4
       typescript: 6.0.3
+      vue-tsc: 3.3.6(typescript@6.0.3)
 
   vite-plugin-inspect@11.4.1(@nuxt/kit@4.4.6(magicast@0.5.3))(vite@8.0.14(@types/node@25.9.1)(esbuild@0.28.1)(jiti@2.7.0)(sass@1.100.0)(terser@5.48.0)(yaml@2.9.0)):
     dependencies:
@@ -16859,6 +16882,12 @@ snapshots:
       '@vue/compiler-sfc': 3.5.38
       pinia: 3.0.4(typescript@6.0.3)(vue@3.5.35(typescript@6.0.3))
       vite: 8.0.14(@types/node@25.9.1)(esbuild@0.28.1)(jiti@2.7.0)(sass@1.100.0)(terser@5.48.0)(yaml@2.9.0)
+
+  vue-tsc@3.3.6(typescript@6.0.3):
+    dependencies:
+      '@volar/typescript': 2.4.28
+      '@vue/language-core': 3.3.6
+      typescript: 6.0.3
 
   vue@3.5.35(typescript@6.0.3):
     dependencies:


### PR DESCRIPTION
## What this adds

A spec-driven development workflow where **design and architecture happen at feature level** and stories are thin delivery slices of an already-designed feature. Splitting happens after architecture, so stories reflect real dependencies and component boundaries.

### Generated from the codebase
- `docs/design/tokens.css` — the app's actual design tokens as CSS custom properties (Tailwind v4 palette usage, semantic colors incl. dark-mode pairings, em-based text sizes from `tailwind.css`, radii/shadows/breakpoints actually in use). Categories where the app deliberately relies on Tailwind defaults are documented as such rather than invented.
- `docs/components.md` — living inventory of all 30 shared components in `src/app/components/` (plus content components and the context layer), with location, purpose, props/variants, and usage. Developer agent must keep it updated; ui-designer and architect must consult it before proposing anything new.

### Workflow scaffolding
- `docs/specs/TEMPLATE-feature.md` + `TEMPLATE-story.md` — feature specs own design/architecture; story specs only reference them and record deltas.
- `docs/specs/README.md` — lifecycles, approval gates, command reference, folder structure, quick lane.
- `.claude/agents/` — product-owner, ui-designer, architect, scrum-master, qa-planner, adversarial-reviewer, developer, qa-verifier. All share common rules (respect CLAUDE.md, never set `status: approved`, only touch their own spec section).
- `.claude/commands/spec/` — `feature`, `design`, `arch`, `review`, `split`, `qa`, `implement`, `verify`, `quick`, `status`.

### Guardrails
- Only Jeroen may set `status: approved` (features AND stories); scrum-master refuses to split and developer refuses to implement anything not approved.
- Story-level conflicts with feature decisions require a flagged feature spec amendment, never a silent override.
- Tailwind rule enforced by architect/developer/qa-verifier: shared components expose variants (CVA-style map + tailwind-merge); `class` passthrough only for parent-layout concerns.

No specs are created yet; the first `/spec:feature` starts the pipeline.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01LTnpxckUH1tNZ272YV6JEA

---
_Generated by [Claude Code](https://claude.ai/code/session_01LTnpxckUH1tNZ272YV6JEA)_